### PR TITLE
make the limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ Test project that serves a RPC proxy. When RAFT consensus is used, the timestamp
     npm install
     ```
 
-*   Configure by editing `config.js`. Set `rpcUrl` to the RPC URL you would like to proxy to. Set `port` to any available port.
+*   Configure by editing `config.js`. Set `rpcUrl` to the RPC URL you would like to proxy to. Set `port` to any available port. Set `limit` to your expected respone/request size.
+
+    Example:
+    ```
+    module.exports = [{
+        rpcUrl: 'http://127.0.0.1:8545',
+        port: 7545,
+        limit: '50kb'
+    }];
+    ```
 
 *   Start server
 

--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 module.exports = [{
-  rpcUrl: 'http://localhost:8545',
-  port: 7545
+  rpcUrl: 'http://172.16.239.12:8545',
+  port: 7545,
+  limit: '30kb'
 }];

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 module.exports = [{
-  rpcUrl: 'http://172.16.239.12:8545',
+  rpcUrl: 'http://127.0.0.1:8545',
   port: 7545,
-  limit: '30kb'
+  limit: '50kb'
 }];

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ for (const proxy of config) {
   const app = new Koa();
 
   app.use(body({
-    limit: '10kb',
+    limit: proxy.limit,
     fallback: true
   }));
 


### PR DESCRIPTION
make the limit size of body configurable for each proxy by adding it to the config.js file and read it from there. Some of our requests were bigger than the current limit of '10kb', and therefore we had to change the limit.